### PR TITLE
Handle the case where a property type is in fact an alias

### DIFF
--- a/macros/src/main/scala/typeformation/package.scala
+++ b/macros/src/main/scala/typeformation/package.scala
@@ -1,6 +1,18 @@
 package object typeformation {
   type Namespace = String
-  case class PropertyType(namespace: Namespace, name: String, properties: List[Property])
+
+  /**
+    * PropertyType usually defines custom types, but sometimes merely aliases primitive types.
+    * This is seen for example on AWS::SSM::PatchBaseLine.PatchGroup
+    * In this case, while a custom PatchGroup property type is define, the documentation specify to use
+    * it as if it was a string
+    */
+  sealed trait PropertyType {
+    def namespace: Namespace
+    def name: String
+  }
+  case class AliasPropertyType(namespace: Namespace, name: String, primitiveType: PrimitiveType) extends PropertyType
+  case class CustomPropertyType(namespace: Namespace, name: String, properties: List[Property]) extends PropertyType
 
   sealed trait AwsType
   sealed trait PrimitiveType extends AwsType


### PR DESCRIPTION
This is seen for example in SSM::PatchBaseLine's PatchGroup.
See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-patchbaseline.html VS the spec:
The former specifies a list of strings for the patch groups, whereas the
later specifies a list of PatchGroup.

In this case, we create an alias from this property type to an
expression of AWS primitive type